### PR TITLE
feat(cli): Add rp alias for realpath command

### DIFF
--- a/fx_bin/cli.py
+++ b/fx_bin/cli.py
@@ -34,6 +34,7 @@ COMMANDS_INFO: List[Tuple[str, str]] = [
     ("backup", "Create timestamped backups of files/dirs"),
     ("root", "Find Git project root directory"),
     ("realpath", "Get absolute path of a file or directory"),
+    ("rp", "Get absolute path (alias for realpath)"),
     ("today", "Create/navigate to today's workspace directory"),
     ("organize", "Organize files into date-based directories"),
     ("list", "List all available commands"),
@@ -447,19 +448,8 @@ def root(output_for_cd: bool) -> int:
         ctx.exit(1)
 
 
-@cli.command()
-@click.argument("path", default=".")
-def realpath(path: str) -> int:
-    """Get absolute path of a file or directory.
-
-    Resolves relative paths, symlinks, and ~ to the canonical absolute path.
-    The path must exist.
-
-    Examples:
-        fx realpath .           # Current directory
-        fx realpath ../foo      # Relative path
-        fx realpath ~/Downloads # Home directory
-    """
+def _run_realpath(path: str) -> int:
+    """Shared implementation for realpath and rp commands."""
     from . import realpath as realpath_module
 
     try:
@@ -478,6 +468,38 @@ def realpath(path: str) -> int:
         click.echo(f"Error: Cannot resolve path: {path} ({e})", err=True)
         ctx = click.get_current_context()
         ctx.exit(1)
+
+
+@cli.command()
+@click.argument("path", default=".")
+def realpath(path: str) -> int:
+    """Get absolute path of a file or directory.
+
+    Resolves relative paths, symlinks, and ~ to the canonical absolute path.
+    The path must exist.
+
+    Examples:
+        fx realpath .           # Current directory
+        fx realpath ../foo      # Relative path
+        fx realpath ~/Downloads # Home directory
+    """
+    return _run_realpath(path)
+
+
+@cli.command()
+@click.argument("path", default=".")
+def rp(path: str) -> int:
+    """Get absolute path of a file or directory.
+
+    Alias for `fx realpath`. Resolves relative paths, symlinks, and ~
+    to the canonical absolute path.
+
+    Examples:
+        fx rp .           # Current directory
+        fx rp ../foo      # Relative path
+        fx rp ~/Downloads # Home directory
+    """
+    return _run_realpath(path)
 
 
 @cli.command()


### PR DESCRIPTION
## Summary
- Add short alias `fx rp` as equivalent to `fx realpath`
- Allows faster typing: 2 characters instead of 8

## Changes
- Extract common logic into `_run_realpath()` helper function
- Add `rp` command that calls the shared implementation
- Add `rp` to COMMANDS_INFO list

## Usage
```bash
fx rp .           # Same as: fx realpath .
fx rp ../foo      # Same as: fx realpath ../foo
fx rp ~/Downloads # Same as: fx realpath ~/Downloads
```

## Test plan
- [x] `fx rp .` returns correct absolute path
- [x] `fx rp --help` shows help
- [x] `fx list` shows both `realpath` and `rp`
- [x] Existing CLI tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)