### PR TITLE
ci: use PyPI trusted publishing

### DIFF
--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -3,6 +3,7 @@ name: CD Release
 on:
   push:
     branches: [main]
+    tags: ['v*']
 
 # Prevent concurrent releases
 concurrency:
@@ -13,15 +14,12 @@ jobs:
   release:
     # Prevent recursion - CRITICAL for avoiding infinite loops
     if: |
+      github.ref == 'refs/heads/main' &&
       github.actor != 'github-actions[bot]' &&
       !contains(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/fx-bin
     permissions:
       contents: write
-      id-token: write  # For trusted publishing
 
     steps:
       - name: Checkout code
@@ -46,18 +44,51 @@ jobs:
           git_committer_name: "github-actions[bot]"
           git_committer_email: "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Get new version
-        if: steps.semantic-release.outputs.version != ''
+      - name: Release status summary
+        if: always()
+        run: |
+          if [[ "${{ steps.semantic-release.outputs.version }}" == "" ]]; then
+            echo "## ℹ️ No Release" >> $GITHUB_STEP_SUMMARY
+            echo "No new version to release (no conventional commits since last release)" >> $GITHUB_STEP_SUMMARY
+          else
+            VERSION="${{ steps.semantic-release.outputs.version }}"
+            echo "📦 New version: $VERSION"
+            echo "## 🎉 New Version Released" >> $GITHUB_STEP_SUMMARY
+            echo "**Version:** $VERSION" >> $GITHUB_STEP_SUMMARY
+            echo "**Next step:** tag workflow \`v$VERSION\` will build and publish to PyPI." >> $GITHUB_STEP_SUMMARY
+          fi
+
+  publish:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/fx-bin
+    permissions:
+      contents: write
+      id-token: write  # For trusted publishing
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Get release version
         id: version
         run: |
-          VERSION=${{ steps.semantic-release.outputs.version }}
+          VERSION="${GITHUB_REF_NAME#v}"
           echo "current_version=$VERSION" >> $GITHUB_OUTPUT
-          echo "📦 New version: $VERSION"
-          echo "## 🎉 New Version Released" >> $GITHUB_STEP_SUMMARY
+          echo "📦 Publishing version: $VERSION"
+          echo "## 🚀 Publishing Release" >> $GITHUB_STEP_SUMMARY
           echo "**Version:** $VERSION" >> $GITHUB_STEP_SUMMARY
 
       - name: Check if version exists on PyPI
-        if: steps.semantic-release.outputs.version != ''
         id: pypi_check
         run: |
           VERSION="${{ steps.version.outputs.current_version }}"
@@ -77,6 +108,10 @@ jobs:
             echo "**Status:** Ready to deploy 🚀" >> $GITHUB_STEP_SUMMARY
           fi
 
+      - name: Install Poetry
+        if: steps.pypi_check.outputs.version_exists == 'false'
+        run: pipx install poetry
+
       - name: Install dependencies and build
         if: steps.pypi_check.outputs.version_exists == 'false'
         run: |
@@ -89,7 +124,7 @@ jobs:
       - name: Upload build artifacts to GitHub Release
         if: steps.pypi_check.outputs.version_exists == 'false'
         env:
-          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_PAT }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           VERSION="${{ steps.version.outputs.current_version }}"
           echo "📎 Uploading build artifacts to GitHub Release v$VERSION..."
@@ -163,11 +198,3 @@ jobs:
           pip install fx-bin==$VERSION
           \`\`\`
           EOF
-
-      - name: Deployment status summary
-        if: always()
-        run: |
-          if [[ "${{ steps.semantic-release.outputs.version }}" == "" ]]; then
-            echo "## ℹ️ No Release" >> $GITHUB_STEP_SUMMARY
-            echo "No new version to release (no conventional commits since last release)" >> $GITHUB_STEP_SUMMARY
-          fi

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -16,6 +16,9 @@ jobs:
       github.actor != 'github-actions[bot]' &&
       !contains(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/fx-bin
     permissions:
       contents: write
       id-token: write  # For trusted publishing
@@ -133,7 +136,6 @@ jobs:
         if: steps.pypi_check.outputs.version_exists == 'false'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: true
 
       - name: Deployment success

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -222,7 +222,8 @@ if: |
 | Secret | Purpose | Scope |
 |--------|---------|-------|
 | `SEMANTIC_RELEASE_PAT` | Git operations, GitHub Release creation | `contents: write` |
-| `PYPI_API_TOKEN` | PyPI package upload | PyPI trusted publishing |
+
+No `PYPI_API_TOKEN` GitHub secret is required. PyPI package upload uses Trusted Publishing/OIDC through the `pypi` GitHub environment.
 
 ---
 
@@ -345,12 +346,12 @@ git push
 **Symptom:** Build succeeds but PyPI deployment fails
 
 **Common Causes:**
-1. Invalid `PYPI_API_TOKEN`
+1. PyPI Trusted Publisher configuration does not match this repository/workflow/environment
 2. Package name conflict
 3. Metadata validation errors
 
 **Solution:**
-1. Verify token in GitHub Secrets
+1. Verify the PyPI publisher uses owner `frankyxhl`, repository `fx_bin`, workflow `cd-release.yml`, and environment `pypi`
 2. Check package name availability on PyPI
 3. Review build logs for metadata issues
 
@@ -389,7 +390,7 @@ git push && git push --tags
 
 # 3. Build and upload
 poetry build
-poetry publish  # Requires PyPI token configured
+poetry publish  # Requires PyPI credentials configured locally
 ```
 
 ---
@@ -407,7 +408,7 @@ Recommended settings for `main` branch:
 ### Secrets Management
 
 - `SEMANTIC_RELEASE_PAT`: Fine-grained PAT with minimal scope
-- `PYPI_API_TOKEN`: Use trusted publishing (OIDC) when possible
+- PyPI deployment uses Trusted Publishing/OIDC; do not store a PyPI API token in GitHub Secrets
 - Never log secrets in workflow outputs
 
 ### Dependency Updates
@@ -474,5 +475,5 @@ graph TB
 
 ---
 
-**Last Updated:** 2026-01-05
+**Last Updated:** 2026-05-06
 **Maintained By:** @frankyxhl

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -26,16 +26,17 @@ The fx_bin project uses a modern CI/CD pipeline built with GitHub Actions, featu
                               │ Merge to main
                               ▼
 ┌─────────────────────────────────────────────────────────────────┐
-│                      CD Release (main branch)                    │
+│                  CD Release (main + v* tag)                      │
 ├─────────────────────────────────────────────────────────────────┤
 │                                                                  │
 │  1. Semantic Release (analyze commits)                          │
 │  2. Version bump + Changelog + Git tag                          │
 │  3. Create GitHub Release                                       │
-│  4. Check PyPI (skip if version exists)                         │
-│  5. Build package (wheel + sdist)                               │
-│  6. Upload artifacts to GitHub Release                          │
-│  7. Deploy to PyPI                                              │
+│  4. v* tag workflow starts                                      │
+│  5. Check PyPI (skip if version exists)                         │
+│  6. Build package (wheel + sdist)                               │
+│  7. Upload artifacts to GitHub Release                          │
+│  8. Deploy to PyPI from pypi environment                        │
 │                                                                  │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -162,13 +163,13 @@ This architecture ensures fast PR feedback while still tracking performance tren
 
 ---
 
-## CD Workflow (Main Branch)
+## CD Workflow (Main Branch and Release Tags)
 
 ### CD Release (`.github/workflows/cd-release.yml`)
 
 **Purpose:** Automated semantic versioning and deployment
 
-**Trigger:** Push to `main` branch (typically via merged PR)
+**Triggers:** Push to `main` branch for semantic-release; push to `v*` tags for package build and PyPI deployment.
 
 **Concurrency:**
 ```yaml
@@ -186,28 +187,30 @@ if: |
 
 #### Release Process
 
-**Step 1: Semantic Release**
+**Step 1: Semantic Release (`main` push)**
 - Analyzes conventional commits since last release
 - Determines version bump (major/minor/patch)
 - Generates changelog
 - Creates Git tag
 - Creates GitHub Release
+- Pushes the `v*` tag that triggers the publish path
 
-**Step 2: Version Check**
+**Step 2: Version Check (`v*` tag push)**
 - Queries PyPI API to check if version exists
 - Skips deployment if version already published
 - Adds job summary for visibility
 
-**Step 3: Build Package**
+**Step 3: Build Package (`v*` tag push)**
 - Installs dependencies with Poetry
 - Builds wheel (`.whl`) and source distribution (`.tar.gz`)
 
-**Step 4: Upload to GitHub Release**
+**Step 4: Upload to GitHub Release (`v*` tag push)**
 - Waits for release availability (retry logic: 10 attempts, 3s delay)
 - Uploads all build artifacts with error handling
 - Validates successful upload for each file
 
-**Step 5: Deploy to PyPI**
+**Step 5: Deploy to PyPI (`v*` tag push)**
+- Runs in the dedicated `pypi` GitHub environment
 - Uses trusted publishing (OIDC)
 - Skip-existing flag as backup safety net
 - Only runs if version doesn't exist on PyPI
@@ -216,6 +219,8 @@ if: |
 - Displays deployment status
 - Includes package links and installation commands
 - Shows skip reason if applicable
+
+This split keeps the `pypi` environment scoped to deployable tag refs, so the environment can safely restrict deployments to `v*` tags without blocking semantic-release on `main`.
 
 #### Secrets Required
 
@@ -234,7 +239,7 @@ No `PYPI_API_TOKEN` GitHub secret is required. PyPI package upload uses Trusted 
 | `ci-test.yml` | PR, develop push | Unit/integration tests | ✅ Yes |
 | `ci-security.yml` | PR, develop push | Security scanning | ✅ Yes |
 | `ci-quality.yml` | PR, develop push | Code quality | ⚠️ Partial (MyPy continues on error) |
-| `cd-release.yml` | main push | Versioning & deployment | N/A |
+| `cd-release.yml` | main push, `v*` tag push | Versioning & deployment | N/A |
 | `codeql.yml` | Schedule, PR | GitHub security analysis | ❌ No |
 | `claude.yml` | Manual | Claude Code integration | ❌ No |
 
@@ -352,8 +357,9 @@ git push
 
 **Solution:**
 1. Verify the PyPI publisher uses owner `frankyxhl`, repository `fx_bin`, workflow `cd-release.yml`, and environment `pypi`
-2. Check package name availability on PyPI
-3. Review build logs for metadata issues
+2. Verify the GitHub `pypi` environment allows the `v*` tag pattern
+3. Check package name availability on PyPI
+4. Review build logs for metadata issues
 
 ---
 
@@ -465,7 +471,8 @@ graph TB
     J -->|Yes| K[Semantic Release]
     J -->|No| L[No Release]
 
-    K --> M{Version on PyPI?}
+    K --> T[Push v* tag]
+    T --> M{Version on PyPI?}
     M -->|No| N[Build & Deploy]
     M -->|Yes| O[Skip Deployment]
 
@@ -475,5 +482,5 @@ graph TB
 
 ---
 
-**Last Updated:** 2026-05-06
+**Last Updated:** 2026-05-07
 **Maintained By:** @frankyxhl


### PR DESCRIPTION
## Summary
- Switch PyPI publishing from `PYPI_API_TOKEN` to PyPI Trusted Publishing/OIDC.
- Split `.github/workflows/cd-release.yml` so `main` pushes run semantic-release, while `v*` tag pushes run the build/upload/PyPI publish path.
- Scope the `pypi` GitHub Actions environment to the tag-driven publish job, so the environment can remain restricted to `v*` tags.
- Update CI/CD docs to describe the tag-based OIDC release flow and troubleshooting values.

## External configuration
- GitHub environment `pypi` has been created/updated for `frankyxhl/fx_bin`.
- Deployment branch/tag policy is restricted to tag pattern `v*`.
- PyPI Trusted Publisher is configured for project `fx-bin` with:
  - Owner: `frankyxhl`
  - Repository: `fx_bin`
  - Workflow: `cd-release.yml`
  - Environment: `pypi`

## Verification
- Compared `chore/trusted-publisher` against `main`: 4 commits ahead, touching `.github/workflows/cd-release.yml` and `docs/CI_CD.md`.
- Parsed `.github/workflows/cd-release.yml` as YAML successfully.
- Confirmed the publish action no longer passes `password: ${{ secrets.PYPI_API_TOKEN }}` and keeps `permissions: id-token: write` on the tag-driven publish job.
- Confirmed PyPI shows the active GitHub Trusted Publisher for `frankyxhl/fx_bin` / `cd-release.yml` / `pypi`.
- Confirmed the original Codex review thread is now outdated after moving `environment: pypi` off the `main` release job.