### PR TITLE
chore: update CHG/PLN document statuses post v2.11.0

### DIFF
--- a/rules/FXB-2106-CHG-Move-FX-Open-Slug-Column-After-Index.md
+++ b/rules/FXB-2106-CHG-Move-FX-Open-Slug-Column-After-Index.md
@@ -1,10 +1,10 @@
 # CHG-2106: Move FX Open Slug Column After Index
 
 **Applies to:** FXB project
-**Last updated:** 2026-05-05
-**Last reviewed:** 2026-05-05
-**Status:** Proposed
-**Related:** COR-1101, COR-1500, COR-1615, COR-1612, FXB-2101, FXB-2105
+**Last updated:** 2026-05-07
+**Last reviewed:** 2026-05-07
+**Status:** Completed
+**Related:** COR-1101, COR-1500, COR-1615, COR-1612, FXB-2101, FXB-2105, PR #63
 **Date:** 2026-05-05
 **Requested by:** Frank Xu
 **Priority:** Medium
@@ -145,3 +145,4 @@ selector less prominent even though it is one of the most important fields.
 | 2026-05-05 | Filled change request for moving Slug to column 2 | Codex |
 | 2026-05-05 | Addressed Trinity fast-review advisories | Codex |
 | 2026-05-05 | Added FXB-2101 supersession note and Flake8 verification | Codex |
+| 2026-05-07 | Implemented + merged (PR #63, v2.11.0) | Claude Code |

--- a/rules/FXB-2107-PLN-Implement-FX-Open-Slug-Column-Order.md
+++ b/rules/FXB-2107-PLN-Implement-FX-Open-Slug-Column-Order.md
@@ -1,8 +1,8 @@
 # PLN-2107: Implement FX Open Slug Column Order
 
 **Applies to:** FXB project
-**Last updated:** 2026-05-05
-**Last reviewed:** 2026-05-05
+**Last updated:** 2026-05-07
+**Last reviewed:** 2026-05-07
 **Status:** Active
 **Related:** FXB-2106, COR-1202, COR-1500, COR-1615, COR-1612
 
@@ -27,14 +27,14 @@ the second position after the index column.
 
 | # | Milestone | Target Date | Status |
 |---|-----------|-------------|--------|
-| 1 | Planning and branch setup | 2026-05-05 | Pending |
-| 2 | Trinity fast-review approval gate | 2026-05-05 | Pending |
-| 3 | RED tests for column order | 2026-05-05 | Pending |
-| 4 | GREEN formatter update | 2026-05-05 | Pending |
-| 5 | REFACTOR and Trinity code fast-review | 2026-05-05 | Pending |
-| 6 | Verification | 2026-05-05 | Pending |
-| 7 | Ready PR, CI, and COR-1615 review loop | 2026-05-05 | Pending |
-| 8 | Merge and release verification | 2026-05-05 | Pending |
+| 1 | Planning and branch setup | 2026-05-05 | Complete |
+| 2 | Trinity fast-review approval gate | 2026-05-05 | Complete |
+| 3 | RED tests for column order | 2026-05-05 | Complete |
+| 4 | GREEN formatter update | 2026-05-05 | Complete |
+| 5 | REFACTOR and Trinity code fast-review | 2026-05-05 | Complete |
+| 6 | Verification | 2026-05-05 | Complete |
+| 7 | Ready PR, CI, and COR-1615 review loop | 2026-05-05 | Complete |
+| 8 | Merge and release verification | 2026-05-05 | Complete |
 
 ---
 
@@ -126,3 +126,4 @@ the second position after the index column.
 | 2026-05-05 | Addressed Trinity fast-review advisories | Codex |
 | 2026-05-05 | Added tag-filtered RED coverage and Flake8 verification | Codex |
 | 2026-05-05 | Added Trinity code fast-review gate before verification | Codex |
+| 2026-05-07 | Implementation complete (shipped in v2.11.0) | Claude Code |

--- a/rules/FXB-2108-CHG-Add-macOS-Directory-Support-to-FX-Open.md
+++ b/rules/FXB-2108-CHG-Add-macOS-Directory-Support-to-FX-Open.md
@@ -3,8 +3,8 @@
 **Applies to:** FXB project
 **Last updated:** 2026-05-07
 **Last reviewed:** 2026-05-07
-**Status:** Proposed
-**Related:** COR-1101, COR-1500, FXB-2100
+**Status:** Active
+**Related:** COR-1101, COR-1500, FXB-2100, PR #63
 **Date:** 2026-05-07
 **Requested by:** Frank Xu
 **Priority:** Medium
@@ -90,3 +90,4 @@ path strings same as files).
 | Date | Change | By |
 |------|--------|----|
 | 2026-05-07 | Initial proposal | Claude Code |
+| 2026-05-07 | Implemented + merged (PR #63, v2.11.0) | Claude Code |

--- a/rules/FXB-2108-CHG-Add-macOS-Directory-Support-to-FX-Open.md
+++ b/rules/FXB-2108-CHG-Add-macOS-Directory-Support-to-FX-Open.md
@@ -3,7 +3,7 @@
 **Applies to:** FXB project
 **Last updated:** 2026-05-07
 **Last reviewed:** 2026-05-07
-**Status:** Active
+**Status:** Completed
 **Related:** COR-1101, COR-1500, FXB-2100, PR #63
 **Date:** 2026-05-07
 **Requested by:** Frank Xu


### PR DESCRIPTION
## Summary

Mark completed documents as done after v2.11.0 release.

- CHG-2106 (slug column order): Proposed → Completed
- CHG-2108 (directory support): Proposed → Completed
- PLN-2107 (slug column implementation plan): milestones marked Complete
- Document index regenerated
- `af validate` clean: 82 documents, 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)