### PR TITLE
chore: fix PR/version attribution for CHG-2106 and PLN-2107

### DIFF
--- a/rules/FXB-2106-CHG-Move-FX-Open-Slug-Column-After-Index.md
+++ b/rules/FXB-2106-CHG-Move-FX-Open-Slug-Column-After-Index.md
@@ -4,7 +4,7 @@
 **Last updated:** 2026-05-07
 **Last reviewed:** 2026-05-07
 **Status:** Completed
-**Related:** COR-1101, COR-1500, COR-1615, COR-1612, FXB-2101, FXB-2105, PR #63
+**Related:** COR-1101, COR-1500, COR-1615, COR-1612, FXB-2101, FXB-2105, PR #61
 **Date:** 2026-05-05
 **Requested by:** Frank Xu
 **Priority:** Medium
@@ -145,4 +145,4 @@ selector less prominent even though it is one of the most important fields.
 | 2026-05-05 | Filled change request for moving Slug to column 2 | Codex |
 | 2026-05-05 | Addressed Trinity fast-review advisories | Codex |
 | 2026-05-05 | Added FXB-2101 supersession note and Flake8 verification | Codex |
-| 2026-05-07 | Implemented + merged (PR #63, v2.11.0) | Claude Code |
+| 2026-05-07 | Implemented + merged (PR #61, v2.10.0) | Claude Code |

--- a/rules/FXB-2107-PLN-Implement-FX-Open-Slug-Column-Order.md
+++ b/rules/FXB-2107-PLN-Implement-FX-Open-Slug-Column-Order.md
@@ -126,4 +126,4 @@ the second position after the index column.
 | 2026-05-05 | Addressed Trinity fast-review advisories | Codex |
 | 2026-05-05 | Added tag-filtered RED coverage and Flake8 verification | Codex |
 | 2026-05-05 | Added Trinity code fast-review gate before verification | Codex |
-| 2026-05-07 | Implementation complete (shipped in v2.11.0) | Claude Code |
+| 2026-05-07 | Implementation complete (shipped in v2.10.0) | Claude Code |


### PR DESCRIPTION
## Summary

CHG-2106 (slug column order) shipped in PR #61 (v2.10.0), not PR #63 (v2.11.0). PR #63 was directory support.

### Fixes
- CHG-2106: `PR #63` → `PR #61` in Related field
- CHG-2106: `PR #63, v2.11.0` → `PR #61, v2.10.0` in Change History
- PLN-2107: `v2.11.0` → `v2.10.0` in Change History

🤖 Generated with [Claude Code](https://claude.com/claude-code)