### PR TITLE
fix(open): shrink Target column before Slug/Name/Tags (#68)

### DIFF
--- a/fx_bin/open_launcher.py
+++ b/fx_bin/open_launcher.py
@@ -361,17 +361,17 @@ def _fit_column_widths(
         min_widths = [1 for _ in widths]
 
     result = list(widths)
-    for index in range(len(result) - 2, -1, -1):
-        while sum(result) > available and result[index] > min_widths[index]:
-            result[index] -= 1
     target_index = len(result) - 1
     while sum(result) > available and result[target_index] > min_widths[target_index]:
         result[target_index] -= 1
     for index in range(len(result) - 2, -1, -1):
-        while sum(result) > available and result[index] > 1:
+        while sum(result) > available and result[index] > min_widths[index]:
             result[index] -= 1
     while sum(result) > available and result[target_index] > 1:
         result[target_index] -= 1
+    for index in range(len(result) - 2, -1, -1):
+        while sum(result) > available and result[index] > 1:
+            result[index] -= 1
     return result
 
 

--- a/tests/unit/test_open_launcher.py
+++ b/tests/unit/test_open_launcher.py
@@ -587,6 +587,37 @@ class TestSelectorResolution(unittest.TestCase):
         self.assertEqual(table_cells(lines[1])[:3], ["#", "Slug", "Name"])
         self.assertTrue(all(len(line) <= 60 for line in lines))
 
+    def test_format_items_shrinks_target_before_slug_name_tags(self) -> None:
+        """Regression for #68: narrow terminal + long URL must keep Slug/Name/Tags
+        at natural width and truncate Target instead."""
+        from fx_bin.open_launcher import OpenItem, format_items
+
+        items = [
+            OpenItem(
+                name="Codex Cloud Analytics",
+                slug="codex-analytics",
+                target="https://chatgpt.com/codex/cloud/settings/analytics/very/long/path",
+                tags=("codex", "analytics"),
+            ),
+        ]
+        output = format_items(items, terminal_width=80)
+
+        lines = output.splitlines()
+        cells = [table_cells(line) for line in lines if line.startswith("|")]
+        header_cells = cells[0]
+        row_cells = cells[1]
+
+        slug_col = header_cells.index("Slug")
+        name_col = header_cells.index("Name")
+        tags_col = header_cells.index("Tags")
+        target_col = header_cells.index("Target")
+
+        self.assertEqual(row_cells[slug_col], "codex-analytics")
+        self.assertEqual(row_cells[name_col], "Codex Cloud Analytics")
+        self.assertEqual(row_cells[tags_col], "codex, analytics")
+        self.assertTrue(row_cells[target_col].endswith("..."))
+        self.assertTrue(all(len(line) <= 80 for line in lines))
+
     def test_format_items_sanitizes_control_chars_and_handles_wide_text(self) -> None:
         from fx_bin.open_launcher import OpenItem, format_items
 


### PR DESCRIPTION
## Summary
- Invert `_fit_column_widths` priority in `fx_bin/open_launcher.py`: shrink Target down to its min_width first, then right-to-left for the other columns, then truncate Target further if still over budget.
- Adds a regression test (`test_format_items_shrinks_target_before_slug_name_tags`) that asserts Slug/Name/Tags keep their natural width and Target gets the `...` truncation on a narrow terminal with a long URL.

## Test plan
- [x] `.venv/bin/python -m pytest tests/unit/test_open_launcher.py -v --no-cov` — 65 passed
- [x] New regression test fails on `main`, passes after the fix
- [x] Existing `test_format_items_truncates_long_target_to_terminal_width` and `test_format_items_preserves_slug_second_in_narrow_terminal` still pass

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)