### PR TITLE
docs: note optional security group for bandit/safety commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,7 +190,8 @@ class SizeEntry:
 
 ```bash
 make test-security
-make security-scan
+make security-scan            # auto-installs the optional `security` group
+# Bare scanner calls need that group first: poetry install --with security
 poetry run safety check
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,9 @@ poetry run black --check fx_bin/ tests/
 ```
 
 ### Security Testing
+
+> `bandit` and `safety` live in the optional `security` dependency group (not in the default `--with dev` env). Install them first: `poetry install --with security`. The `make security-scan` / `tox -e security` targets do this automatically.
+
 ```bash
 # Run security analysis with bandit
 poetry run bandit -r fx_bin/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,8 @@ Ready to contribute? Here's how to set up `fx_bin` for local development.
     poetry run flake8 fx_bin/
     poetry run mypy fx_bin/
     
-    # Run security checks
+    # Run security checks (bandit/safety are in the optional `security` group;
+    # install them first with: poetry install --with security)
     poetry run bandit -r fx_bin/
     poetry run safety check
     ```

--- a/README.md
+++ b/README.md
@@ -532,7 +532,7 @@ poetry run flake8 fx_bin/
 # Type checking
 poetry run mypy fx_bin/
 
-# Security scan
+# Security scan (needs the optional security group: poetry install --with security)
 poetry run bandit -r fx_bin/
 ```
 
@@ -594,8 +594,10 @@ poetry run pytest -m performance
 
 ### Security Testing
 
+> `bandit` and `safety` are in the optional `security` dependency group (not installed by `poetry install --with dev`). Install them first: `poetry install --with security`.
+
 ```bash
-# Run security test suite
+# Run security test suite (no extra deps needed)
 poetry run pytest tests/test_*security*.py -v
 
 # Static security analysis

--- a/SKILL.md
+++ b/SKILL.md
@@ -801,7 +801,8 @@ poetry run flake8 fx_bin/
 # Type checking with mypy
 poetry run mypy fx_bin/
 
-# Security scan with bandit
+# Security scan with bandit (bandit/safety are in the optional security group:
+# run `poetry install --with security` first)
 poetry run bandit -r fx_bin/
 
 # Check dependency vulnerabilities

--- a/docs/testing/tdd_implementation_summary.md
+++ b/docs/testing/tdd_implementation_summary.md
@@ -138,7 +138,8 @@ poetry run pytest tests/test_*security*.py -v
 # Run all tests with coverage
 poetry run pytest --cov=fx_bin --cov-report=html
 
-# Run security analysis
+# Run security analysis (install the optional security group first:
+# poetry install --with security)
 poetry run bandit -r fx_bin/
 poetry run safety check
 

--- a/rules/FXB-2109-SOP-Code-Review-AI-Assisted-Quick-Reference.md
+++ b/rules/FXB-2109-SOP-Code-Review-AI-Assisted-Quick-Reference.md
@@ -124,6 +124,8 @@ skips = ["B101"]  # assert_used
 
 #### Unified Check Command
 
+> `bandit`/`safety` are in the optional `security` group — run `poetry install --with security` first (or use `make check`, which installs it).
+
 ```bash
 poetry run black --check fx_bin/ tests/ && \
   poetry run mypy fx_bin/ && \

--- a/rules/FXB-2109-SOP-Code-Review-AI-Assisted-Quick-Reference.md
+++ b/rules/FXB-2109-SOP-Code-Review-AI-Assisted-Quick-Reference.md
@@ -124,7 +124,7 @@ skips = ["B101"]  # assert_used
 
 #### Unified Check Command
 
-> `bandit`/`safety` are in the optional `security` group — run `poetry install --with security` first (or use `make check`, which installs it).
+> `bandit`/`safety` are in the optional `security` group — run `poetry install --with security` once before the command below. (Note: `make check` is **not** a substitute here; it only runs lint/format/type + Bandit, skipping `safety check` and the test suite.)
 
 ```bash
 poetry run black --check fx_bin/ tests/ && \


### PR DESCRIPTION
## What

Follow-up to #76 (which moved `bandit`/`safety` into the optional `security` dependency group). Updates the **live instructional docs** so the documented `poetry run bandit` / `poetry run safety check` commands don't fail with "command not found" in the default `--with dev` environment.

Each security-scan block now notes that those scanners require `poetry install --with security` first (the `make` / `tox` targets already self-install, fixed in #76).

## Files touched (live docs only)

- `README.md` — Security Testing + Code Quality blocks
- `CONTRIBUTING.md` — security checks step
- `CLAUDE.md` — Security Testing section
- `SKILL.md` — security scan block
- `AGENTS.md` — security commands block
- `rules/FXB-2109-*` — review SOP unified check command
- `docs/testing/tdd_implementation_summary.md` — security analysis block

## Deliberately NOT touched

Historical / point-in-time records, which should not be rewritten: `docs/changelog/`, `docs/sessions/`, `docs/plans/completed-*`, `openspec/changes/archive/`, `docs/decision-log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)