### PR TITLE
feat(open): add 'fx o' as a shorthand alias for 'fx open'

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ poetry run fx --help
 | `fx files` | Count files in directories | Pattern matching, recursive search, detailed stats |
 | `fx size` | Analyze file/directory sizes | Human-readable units, sorting, limit results |
 | `fx ff` | Find files by keyword | Multiple search modes, content search, regex support |
-| `fx open` | Open saved URLs/files and direct targets | Local TOML registry, tags, browser/app selection |
+| `fx open` (`fx o`) | Open saved URLs/files and direct targets | Local TOML registry, tags, browser/app selection |
 | `fx filter` | Filter files by extension | Time-based sorting, multiple formats, recursive search |
 | `fx replace` | Replace text in files | Atomic file operations, safe text replacement |
 | `fx backup` | Create timestamped backups | File/dir backup, compression |
@@ -274,9 +274,10 @@ fx open
 fx open --all
 fx open --disabled
 
-# Open by slug or index
+# Open by slug or index ('o' is a shorthand alias for 'open')
 fx open cc-usage
 fx open 3
+fx o cc-usage
 
 # Filter the list before selecting
 fx open --tag usage 2

--- a/fx_bin/cli.py
+++ b/fx_bin/cli.py
@@ -31,6 +31,7 @@ COMMANDS_INFO: List[Tuple[str, str]] = [
     ("ff", "Find files by keyword"),
     ("fff", "Find first file matching keyword (alias for ff --first)"),
     ("open", "Open saved URLs/files and direct targets"),
+    ("o", "Open saved URLs/files (alias for open)"),
     ("filter", "Filter files by extension"),
     ("replace", "Replace text in files"),
     ("backup", "Create timestamped backups of files/dirs"),
@@ -648,6 +649,7 @@ def open_command(
       fx open https://example.com          # Open direct URL
       fx open ./diagram.png --app Preview  # Open local file on macOS
       fx open cc-usage --browser Firefox   # Temporary macOS browser override
+      fx o cc-usage                        # 'o' is an alias for 'open'
 
     \b
     Add entries:
@@ -778,6 +780,9 @@ def open_command(
         return 0
     except open_launcher.OpenError as e:
         raise click.ClickException(str(e)) from e
+
+
+cli.add_command(open_command, "o")
 
 
 def _run_open_search(

--- a/tests/integration/test_open_cli.py
+++ b/tests/integration/test_open_cli.py
@@ -867,5 +867,86 @@ target = "{resolved_target}"
                 self.assertEqual(plan.args[1], resolved_target)
 
 
+class TestOpenAlias(unittest.TestCase):
+    """Test the fx o alias for fx open."""
+
+    CONFIG = """
+[[items]]
+name = "Claude Usage"
+slug = "cc-usage"
+target = "https://claude.ai/settings/usage"
+tags = ["usage"]
+
+[[items]]
+name = "SportPlus Snooker"
+slug = "sp"
+target = "https://en97.sportplus.live/snooker/"
+tags = ["sports"]
+""".strip()
+
+    def setUp(self) -> None:
+        self.runner = CliRunner()
+
+    def _config(self, temp_dir: str) -> Path:
+        config_path = Path(temp_dir) / "open.toml"
+        config_path.write_text(self.CONFIG, encoding="utf-8")
+        return config_path
+
+    def test_o_alias_lists_same_as_open(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_path = self._config(temp_dir)
+
+            aliased = self.runner.invoke(cli, ["o", "--config", str(config_path)])
+            full = self.runner.invoke(cli, ["open", "--config", str(config_path)])
+
+        self.assertEqual(aliased.exit_code, 0, aliased.output)
+        self.assertEqual(aliased.output, full.output)
+
+    def test_o_alias_opens_target(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_path = self._config(temp_dir)
+
+            with patch("fx_bin.open_launcher.execute_dispatch_plan") as execute:
+                result = self.runner.invoke(
+                    cli, ["o", "--config", str(config_path), "cc-usage"]
+                )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("Opened Claude Usage", result.output)
+        execute.assert_called_once()
+
+    def test_o_alias_honors_tag_filter(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_path = self._config(temp_dir)
+
+            result = self.runner.invoke(
+                cli, ["o", "--config", str(config_path), "--tag", "sports"]
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("SportPlus Snooker", result.output)
+        self.assertNotIn("Claude Usage", result.output)
+
+    def test_o_alias_reports_errors_like_open(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_path = self._config(temp_dir)
+
+            aliased = self.runner.invoke(
+                cli, ["o", "--config", str(config_path), "nope"]
+            )
+            full = self.runner.invoke(
+                cli, ["open", "--config", str(config_path), "nope"]
+            )
+
+        self.assertEqual(aliased.exit_code, 1)
+        self.assertEqual(aliased.output, full.output)
+
+    def test_list_command_documents_alias(self) -> None:
+        result = self.runner.invoke(cli, ["list"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("alias for open", result.output)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

`fx o` now does everything `fx open` does.

```bash
fx o                  # list saved targets
fx o cc-usage         # open by slug
fx o --tag usage 2    # open by index in a tag-filtered list
```

## How

One line — the existing `open_command` is registered under a second name:

```python
cli.add_command(open_command, "o")
```

No duplicate command declaration, so all 15 options, the token subcommands (`add` / `search` / `delete` / `disable` / `enable`) and the help text stay in exactly one place and can never drift apart. Click derives the usage line from the invoked name, so `fx o --help` prints `Usage: fx o [OPTIONS]`.

`fx list` gains a row for the alias, matching how `fff` and `rp` are already listed.

## Tests

5 new integration tests in `tests/integration/test_open_cli.py::TestOpenAlias`:

- `fx o` and `fx open` produce byte-identical list output
- alias opens a target (dispatch plan executed once)
- alias honors `--tag` filtering
- alias produces identical error output on an unknown selector
- `fx list` documents the alias

`125 passed` across `test_open_cli.py`, `test_open_launcher.py`, `test_cli.py`. Full suite green (702 passed, excluding `tests/integration/test_today_cli.py`, which replaces the pytest process mid-run on `main` too — pre-existing, unrelated). flake8 clean, black clean, mypy strict clean.

## Notes

Independent of #(fx open copy) — both branch off `main` and touch different parts of the `fx open` docstring; whichever merges second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Q9py8f6LdS69Kvujc5UZz