### PR TITLE
docs: sync command reference with actual CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,12 +123,18 @@ poetry run fx --help
 |---------|-------------|--------------|
 | `fx files` | Count files in directories | Pattern matching, recursive search, detailed stats |
 | `fx size` | Analyze file/directory sizes | Human-readable units, sorting, limit results |
-| `fx ff` | Find files by keyword | Multiple search modes, content search, regex support |
+| `fx ff` | Find files by keyword | Path-segment matching (`dir/file`), clipboard copy by default, smart exclusions |
+| `fx fff` | Find first file matching keyword | Alias for `fx ff --first`, fast single lookup |
 | `fx open` (`fx o`) | Open saved URLs/files and direct targets | Local TOML registry, tags, browser/app selection |
 | `fx filter` | Filter files by extension | Time-based sorting, multiple formats, recursive search |
 | `fx replace` | Replace text in files | Atomic file operations, safe text replacement |
 | `fx backup` | Create timestamped backups | File/dir backup, compression |
+| `fx root` | Find Git project root directory | `cd $(fx root)`, script integration |
+| `fx realpath` (`fx rp`) | Get absolute path of a file/directory | Resolves `~`, symlinks, relative paths |
+| `fx today` | Create/navigate to today's workspace | Date-based daily directories |
+| `fx organize` | Organize files into date-based directories | Photo sorting, dataset management |
 | `fx list` | List all available commands | Help and usage information |
+| `fx version` | Show version and system information | Diagnostics |
 
 ### Detailed Command Documentation
 
@@ -210,10 +216,20 @@ fx filter txt --no-recursive
 #### 🔍 fx ff - File Finder
 
 Find files whose names contain a keyword, with powerful filtering options and smart exclusions.
+Results are printed as absolute paths and copied to the clipboard by default when run
+interactively (v2.13.0+), so you can paste them straight into another command or app.
 
 ```bash
 # Basic usage: Find files containing "test" in their names
 fx ff test
+
+# Path-segment matching (v2.13.0+): a keyword containing "/" matches the
+# relative path, not just the file name
+fx ff docs/setup
+fx ff frank_maintain/file-organizer.md
+
+# Skip the clipboard copy
+fx ff report --no-copy
 
 # Find configuration files
 fx ff config
@@ -262,6 +278,8 @@ fx ff test --exclude coverage --exclude .nyc_output
 **Options:**
 - `--include-ignored`: Include `.git`, `.venv`, `node_modules` (default skips these heavy directories)
 - `--exclude NAME`: Exclude names or glob patterns; repeatable for complex filtering
+- `--first`: Stop after the first match (same as `fx fff`)
+- `--no-copy`: Do not copy results to the clipboard (piped/scripted output never touches the clipboard)
 
 #### 🔗 fx open - URL and File Launcher
 
@@ -449,6 +467,38 @@ $ ft  # Short alias for fx today
 ```
 
 See [fx-today-setup.md](docs/fx-today-setup.md) for shell integration setup.
+
+#### 🧭 fx root - Git Project Root
+
+Find the Git project root by searching upward for a `.git` directory.
+
+```bash
+fx root              # Show root directory
+cd $(fx root --cd)   # Jump to project root in scripts
+```
+
+See [fx-root-setup.md](docs/fx-root-setup.md) for shell integration setup.
+
+#### 📍 fx realpath / fx rp - Absolute Path
+
+Resolve a relative path, `~`, or symlink to its canonical absolute path (the path must exist).
+
+```bash
+fx realpath .            # Current directory
+fx rp ../foo             # Relative path (alias)
+fx rp ~/Downloads        # Home directory
+```
+
+#### 🗂️ fx organize - Date-Based File Organizer
+
+Organize files from a source directory into date-based folders (e.g. `2026/202601/20260110/`).
+
+```bash
+fx organize ~/Photos                    # Organize photos by date
+fx organize ~/Downloads -o ~/Sorted     # Custom output directory
+fx organize . --dry-run                 # Preview without changes
+fx organize . -i "*.jpg" -i "*.png"     # Only images
+```
 
 ## 📚 Usage Examples
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ poetry run fx --help
 | `fx filter` | Filter files by extension | Time-based sorting, multiple formats, recursive search |
 | `fx replace` | Replace text in files | Atomic file operations, safe text replacement |
 | `fx backup` | Create timestamped backups | File/dir backup, compression |
-| `fx root` | Find Git project root directory | `cd $(fx root)`, script integration |
+| `fx root` | Find Git project root directory | `cd "$(fx root --cd)"`, script integration |
 | `fx realpath` (`fx rp`) | Get absolute path of a file/directory | Resolves `~`, symlinks, relative paths |
 | `fx today` | Create/navigate to today's workspace | Date-based daily directories |
 | `fx organize` | Organize files into date-based directories | Photo sorting, dataset management |
@@ -473,8 +473,8 @@ See [fx-today-setup.md](docs/fx-today-setup.md) for shell integration setup.
 Find the Git project root by searching upward for a `.git` directory.
 
 ```bash
-fx root              # Show root directory
-cd $(fx root --cd)   # Jump to project root in scripts
+fx root                  # Show root directory (with description)
+cd "$(fx root --cd)"     # Jump to project root in scripts
 ```
 
 See [fx-root-setup.md](docs/fx-root-setup.md) for shell integration setup.

--- a/docs/site/commands/ff.md
+++ b/docs/site/commands/ff.md
@@ -7,7 +7,9 @@ Find files whose names contain a keyword, with powerful filtering options and sm
 `fx ff` provides fast file discovery with keyword matching, flexible exclusion patterns, and smart default settings. Perfect for debugging, code navigation, and project analysis.
 
 **Key Features:**
-- 🔍 Keyword and pattern-based file finding
+- 🔍 Substring keyword matching on file/directory names
+- 🛤️ Path-segment matching: a keyword containing `/` matches the relative path (v2.13.0+)
+- 📋 Results copied to the clipboard by default in interactive use (v2.13.0+)
 - 🚀 First-match mode for quick lookups (`--first`)
 - 🎯 Smart exclusions (.git, .venv, node_modules)
 - 📝 Multiple exclusion patterns (repeatable)
@@ -23,10 +25,11 @@ fx ff [OPTIONS] KEYWORD
 
 | Parameter | Type | Default | Description |
 |-----------|------|----------|-------------|
-| `KEYWORD` | string | - | Keyword or pattern to search for (required) |
+| `KEYWORD` | string | - | Substring to search for; contains `/` → matched against the relative path (required) |
 | `--first` | flag | False | Stop after first match (for speed) |
 | `--include-ignored` | flag | False | Include default-ignored dirs (.git, .venv, node_modules) |
 | `--exclude` | string | - | Exclude names or glob patterns (repeatable) |
+| `--no-copy` | flag | False | Do not copy results to the clipboard |
 
 ## Examples
 
@@ -49,6 +52,36 @@ Find all Python files (using partial match):
 ```bash
 fx ff .py
 ```
+
+### Path-Segment Matching (v2.13.0+)
+
+A keyword containing `/` is matched against the path relative to the current
+directory instead of the file name alone, so you can pin a match to a
+directory:
+
+```bash
+# Only matches file-organizer.md inside frank_maintain/
+fx ff frank_maintain/file-organizer.md
+
+# Any path containing "docs/setup"
+fx ff docs/setup
+```
+
+On Windows both `/` and `\` work.
+
+### Clipboard Copy (v2.13.0+)
+
+When run interactively (stdout is a terminal), the printed absolute paths are
+also copied to the clipboard — the result exists to be pasted somewhere else.
+
+```bash
+fx ff report            # Results printed AND on the clipboard
+fx ff report --no-copy  # Skip the clipboard
+fx ff report | wc -l    # Piped output never touches the clipboard
+```
+
+If no clipboard tool is available (e.g. headless Linux without wl-clipboard or
+xclip), `fx ff` prints a warning to stderr and still exits successfully.
 
 ### First Match Only
 
@@ -216,22 +249,22 @@ fx ff model --exclude node_modules --exclude __pycache__
 
 #### Scenario 7: Test Discovery
 
-Find unit tests:
+Find unit tests (KEYWORD is a substring, not a glob — use `tests/` path matching or a distinctive fragment):
 
 ```bash
-fx ff "*unit*test*" --exclude node_modules --exclude __pycache__
+fx ff unit_test --exclude node_modules --exclude __pycache__
 ```
 
 Find integration tests:
 
 ```bash
-fx ff "*integration*test*" --exclude node_modules
+fx ff tests/integration
 ```
 
 Find e2e tests:
 
 ```bash
-fx ff "*e2e*test*" --exclude node_modules
+fx ff e2e --exclude node_modules
 ```
 
 #### Scenario 8: Code Review

--- a/docs/site/commands/fff.md
+++ b/docs/site/commands/fff.md
@@ -11,6 +11,8 @@ Find first file matching KEYWORD. Returns only the first match and exits immedia
 - 🎯 Perfect for shell scripts and aliases
 - 🔄 Returns single result immediately
 - 📝 Uses smart exclusions (.git, .venv, node_modules)
+- 🛤️ Path-segment matching when KEYWORD contains `/` (v2.13.0+)
+- 📋 Copies the match to the clipboard in interactive use; `--no-copy` disables (v2.13.0+)
 
 ## Usage
 

--- a/docs/site/commands/realpath.md
+++ b/docs/site/commands/realpath.md
@@ -1,0 +1,54 @@
+# Command: fx realpath (fx rp)
+
+Get the absolute path of a file or directory.
+
+## Overview
+
+`fx realpath` resolves relative paths, symlinks, and `~` to the canonical
+absolute path. The path must exist. `fx rp` is a shorter alias for the same
+command.
+
+**Key Features:**
+
+- 📍 Canonical absolute path (symlinks resolved)
+- 🏠 `~` expansion
+- ⚡ `fx rp` short alias
+- ❌ Fails clearly when the path does not exist
+
+## Usage
+
+```bash
+fx realpath [PATH]
+fx rp [PATH]
+```
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `PATH` | string | `.` | File or directory to resolve (must exist) |
+
+## Examples
+
+```bash
+# Current directory
+fx realpath .
+
+# Relative path
+fx rp ../foo
+
+# Home directory
+fx rp ~/Downloads
+
+# Use in scripts
+open "$(fx rp ./build/report.html)"
+```
+
+## See Also
+
+- [`fx root`](root.md) - Find Git project root
+- [`fx ff`](ff.md) - Find files by keyword (prints absolute paths)
+
+---
+
+**Need more examples?** See [Use Cases](../use-cases/daily-workflow.md) for real-world workflows.

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -100,6 +100,7 @@ fx replace "old_text" "new_text" file.txt
 | `fx backup` | Create timestamped backups | Safe file operations |
 | `fx organize` | Organize files by date | Photo sorting, dataset management |
 | `fx root` | Find Git project root | Navigation, script integration |
+| `fx realpath` (`fx rp`) | Get absolute path of a file/directory | Resolves `~`, symlinks, relative paths |
 | `fx today` | Daily workspace manager | Daily work organization |
 
 ---

--- a/docs/site/quick-start.md
+++ b/docs/site/quick-start.md
@@ -243,6 +243,7 @@ For detailed information about each command, see:
 - [`fx backup`](commands/backup.md) - Create timestamped backups
 - [`fx organize`](commands/organize.md) - Organize files by date
 - [`fx root`](commands/root.md) - Find Git project root
+- [`fx realpath`](commands/realpath.md) - Get absolute path (`fx rp`)
 - [`fx today`](commands/today.md) - Create daily workspace
 
 ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
     - commands/backup.md
     - commands/organize.md
     - commands/root.md
+    - commands/realpath.md
     - commands/today.md
   - Use Cases:
     - use-cases/daily-workflow.md


### PR DESCRIPTION
## What

Documentation catch-up — no behavior change, no AF artifact needed (doc sync against already-shipped commands).

- **README overview table** was missing 6 commands (`fff`, `root`, `realpath`/`rp`, `today`, `organize`, `version`) and the `fx ff` row claimed *content search + regex support*, which `ff` never had. Table now matches `fx list`.
- **README**: `ff` section documents v2.13.0 path-segment matching + default clipboard copy (`--no-copy`, `--first`); added brief `root` / `realpath` / `organize` sections.
- **Docs site**: new `commands/realpath.md` page (was completely undocumented) + mkdocs nav entry, index table row, quick-start link.
- **ff.md / fff.md**: v2.13.0 behavior documented; fixed bogus glob-keyword examples (`fx ff "*unit*test*"` — `ff` matches substrings, not globs).

## Verification

`mkdocs build` passes locally (uvx mkdocs-material); only pre-existing INFO notices. `docs:` commit → no release per semantic-release config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQcFrofPTcsnEtrVDUDZNG